### PR TITLE
Downsample

### DIFF
--- a/Assets/Scenes/TopDown/TopDownSandbox.unity
+++ b/Assets/Scenes/TopDown/TopDownSandbox.unity
@@ -1282,6 +1282,7 @@ GameObject:
   - component: {fileID: 963194226}
   - component: {fileID: 963194229}
   - component: {fileID: 963194230}
+  - component: {fileID: 963194231}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -1376,12 +1377,27 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 963194225}
-  m_Enabled: 0
+  m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 2f6bccdd3074c5643ad03b5e650a0d69, type: 3}
+  m_Script: {fileID: 11500000, guid: e9bf7b47117dae745b913089a987a55e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  objectToFollow: {fileID: 528994442}
+  DownsamplingCamera: {fileID: 0}
+  renderScale: 0.1
+  filterMode: 0
+--- !u!114 &963194231
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 963194225}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c394753957087e742b76611611da5728, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  EnableKey: 9
 --- !u!1 &980443610
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Utility/DownsampleCamera.cs
+++ b/Assets/Scripts/Utility/DownsampleCamera.cs
@@ -1,0 +1,38 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class DownsampleCamera : MonoBehaviour
+{
+    public Camera DownsamplingCamera;
+    [Range(0.001F, 1.00F)]
+    public float renderScale = 1.0F;
+    public FilterMode filterMode = FilterMode.Point;
+
+    private Rect originalScreen;
+    private Rect downsampledScreen;
+
+    void Start()
+    {
+        DownsamplingCamera = Camera.main;
+    }
+
+    void OnDestroy()
+    {
+        DownsamplingCamera.rect = originalScreen;
+    }
+
+    void OnPreRender()
+    {
+        originalScreen = DownsamplingCamera.rect;
+        downsampledScreen.Set(originalScreen.x, originalScreen.y, originalScreen.width * renderScale, originalScreen.height * renderScale);
+        DownsamplingCamera.rect = downsampledScreen;
+    }
+
+    void OnRenderImage(RenderTexture src, RenderTexture dest)
+    {
+        DownsamplingCamera.rect = originalScreen;
+        src.filterMode = filterMode;
+        Graphics.Blit(src, dest);
+    }
+}

--- a/Assets/Scripts/Utility/DownsampleCamera.cs.meta
+++ b/Assets/Scripts/Utility/DownsampleCamera.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e9bf7b47117dae745b913089a987a55e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Utility/DownsampleController.cs
+++ b/Assets/Scripts/Utility/DownsampleController.cs
@@ -1,0 +1,23 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class DownsampleController : MonoBehaviour
+{
+    public KeyCode EnableKey = KeyCode.Tab;
+
+    // Start is called before the first frame update
+    void Start()
+    {
+        
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        if (Input.GetKeyDown(EnableKey))
+        {
+            gameObject.GetComponent<DownsampleCamera>().enabled = !gameObject.GetComponent<DownsampleCamera>().enabled;
+        }
+    }
+}

--- a/Assets/Scripts/Utility/DownsampleController.cs.meta
+++ b/Assets/Scripts/Utility/DownsampleController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c394753957087e742b76611611da5728
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Gives us the 32-bit look for free by downsampling the viewport and scaling it back up without interpolation.  Currently controlled with the 'Tab' key, but that can be set in the `DownsampleController.cs` script.
Closes #44 .